### PR TITLE
simplification: get rid of builder for TeamCityInstance

### DIFF
--- a/src/main/kotlin/api.kt
+++ b/src/main/kotlin/api.kt
@@ -14,13 +14,10 @@ public trait TeamCityInstance {
     fun rootProject(): Project
 
     companion object {
-        fun builder(serverUrl: String): TeamCityInstanceBuilder = TeamCityInstanceBuilderImpl(serverUrl)
+        fun guestAuth(serverUrl: String): TeamCityInstance = createGuestAuthInstance(serverUrl)
+        fun httpAuth(serverUrl: String, username: String, password: String): TeamCityInstance
+                = createHttpAuthInstance(serverUrl, username, password)
     }
-}
-
-public trait TeamCityInstanceBuilder {
-    fun httpAuth(username: String, password: String): TeamCityInstanceBuilder
-    fun build(): TeamCityInstance
 }
 
 public data class ProjectId(val stringId: String)

--- a/src/main/kotlin/implementation.kt
+++ b/src/main/kotlin/implementation.kt
@@ -18,24 +18,13 @@ private val LOG = LoggerFactory.getLogger("team-rest-client")
 
 private val teamCityServiceDateFormat = SimpleDateFormat("yyyyMMdd'T'HHmmssZ", Locale.ENGLISH)
 
-private class TeamCityInstanceBuilderImpl(private val serverUrl: String): TeamCityInstanceBuilder {
-    private var username: String? = null
-    private var password: String? = null
+private fun createGuestAuthInstance(serverUrl: String): TeamCityInstanceImpl {
+    return TeamCityInstanceImpl(serverUrl, "guestAuth", null)
+}
 
-    override fun httpAuth(username: String, password: String): TeamCityInstanceBuilder {
-        this.username = username
-        this.password = password
-        return this
-    }
-
-    override fun build(): TeamCityInstance {
-        if (username != null && password != null) {
-            val authorization = Base64.encodeBase64String("$username:$password".toByteArray())
-            return TeamCityInstanceImpl(serverUrl, "httpAuth", authorization)
-        } else {
-            return TeamCityInstanceImpl(serverUrl, "guestAuth", null)
-        }
-    }
+private fun createHttpAuthInstance(serverUrl: String, username: String, password: String): TeamCityInstanceImpl {
+    val authorization = Base64.encodeBase64String("$username:$password".toByteArray())
+    return TeamCityInstanceImpl(serverUrl, "httpAuth", authorization)
 }
 
 private class TeamCityInstanceImpl(private val serverUrl: String,


### PR DESCRIPTION
Looks like we don't need builder here anymore, calls like
`TeamCityInstance.builder("http://teamcity.jetbrains.com").build().builds(...)`
contains word 'build' too many times.