### PR TITLE
Support build revisions fetching 

### DIFF
--- a/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -112,6 +112,8 @@ interface Build {
 
     fun fetchParameters(): List<Parameter>
 
+    fun fetchRevisions(): List<Revision>
+
     fun fetchChanges(): List<Change>
 
     fun fetchPinInfo(): PinInfo?
@@ -161,4 +163,10 @@ enum class BuildStatus {
 interface PinInfo {
     val user: User
     val time: Date
+}
+
+interface Revision {
+    val version: String
+    val vcsBranchName: String
+    val vcsRoot: VcsRoot
 }

--- a/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -248,6 +248,17 @@ private class ParameterImpl(private val bean: ParameterBean) : Parameter {
         get() = bean.own
 }
 
+private class RevisionImpl(private val bean: RevisionBean) : Revision {
+    override val version: String
+        get() = bean.version!!
+
+    override val vcsBranchName: String
+        get() = bean.vcsBranchName!!
+
+    override val vcsRoot: VcsRoot
+        get() = VcsRootImpl(bean.`vcs-root-instance`!!)
+}
+
 private class BuildImpl(private val bean: BuildBean,
                         private val isFullBuildBean: Boolean,
                         private val service: TeamCityService) : Build {
@@ -283,6 +294,8 @@ private class BuildImpl(private val bean: BuildBean,
     override fun fetchPinInfo() = fullBuildBean.pinInfo?.let {PinInfoImpl(it)}
 
     override fun fetchParameters(): List<Parameter> = fullBuildBean.properties!!.property!!.map { ParameterImpl(it) }
+
+    override fun fetchRevisions(): List<Revision> = fullBuildBean.revisions!!.revision!!.map { RevisionImpl(it) }
 
     override fun fetchChanges(): List<Change> = service.changes("build:${id.stringId}", "change(id,version,user,date,comment)").change!!.map { ChangeImpl(it) }
 

--- a/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
@@ -104,6 +104,8 @@ internal open class BuildBean {
     var startDate: String? = null
     var finishDate: String? = null
 
+    var revisions: RevisionsBean? = null
+
     var pinInfo: PinInfoBean? = null
 
     var properties: ParametersBean? = ParametersBean()
@@ -170,4 +172,14 @@ internal class ParameterBean {
 internal class PinInfoBean {
     var user: UserBean? = null
     var timestamp: String? = null
+}
+
+internal class RevisionsBean {
+    var revision: List<RevisionBean>? = ArrayList()
+}
+
+internal class RevisionBean {
+    var version: String? = null
+    var vcsBranchName: String? = null
+    var `vcs-root-instance`: VcsRootBean? = null
 }

--- a/src/test/kotlin/org.jetbrains.teamcity.rest/BranchesTest.kt
+++ b/src/test/kotlin/org.jetbrains.teamcity.rest/BranchesTest.kt
@@ -28,6 +28,7 @@ class BranchesTest {
             .list().forEach {
       it.fetchParameters()
       it.fetchChanges()
+      it.fetchRevisions()
       it.getArtifacts()
     }
   }

--- a/src/test/kotlin/org.jetbrains.teamcity.rest/BuildTest.kt
+++ b/src/test/kotlin/org.jetbrains.teamcity.rest/BuildTest.kt
@@ -1,0 +1,24 @@
+package org.jetbrains.teamcity.rest
+
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class BuildTest {
+  @Before
+  fun setupLog4j() {
+    setupLog4jDebug()
+  }
+
+  @Test
+  fun test_build_fetch_revisions() {
+    publicInstance().builds()
+            .fromConfiguration(compileExamplesConfiguration)
+            .limitResults(10)
+            .list()
+            .forEach {
+              val revisions = it.fetchRevisions()
+              Assert.assertTrue(revisions.isNotEmpty())
+            }
+  }
+}


### PR DESCRIPTION
Provide API for fetching version control revisions checked out in corresponding build.
No additional http requests made in implementation to obtain revisions data, the request made by  `build(...)` method already receives that data though it's not parsed.