### PR TITLE
kotlin 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: java
+jdk:
+  - oraclejdk8
+  

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.0.0'
+    ext.kotlin_version = '1.1.2-2'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Upgrade to Kotlin 1.1.2-2 (the latest version for now)

It may cause problems if the library is being used in projects with older versions of Kotlin. I have no such examples in mind, so, maybe it's worth upgrading