### PR TITLE
add "Accept: application/json" header to all requests

### DIFF
--- a/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -39,7 +39,6 @@ internal class TeamCityInstanceImpl(private val serverUrl: String,
             .setLog({ RestLOG.debug(it) })
             .setLogLevel(if (logResponses) retrofit.RestAdapter.LogLevel.FULL else retrofit.RestAdapter.LogLevel.HEADERS_AND_ARGS)
             .setRequestInterceptor({ request ->
-                request.addHeader("Accept", "application/json")
                 if (basicAuthHeader != null) {
                     request.addHeader("Authorization", "Basic $basicAuthHeader")
                 }

--- a/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -39,6 +39,7 @@ internal class TeamCityInstanceImpl(private val serverUrl: String,
             .setLog({ RestLOG.debug(it) })
             .setLogLevel(if (logResponses) retrofit.RestAdapter.LogLevel.FULL else retrofit.RestAdapter.LogLevel.HEADERS_AND_ARGS)
             .setRequestInterceptor({ request ->
+                request.addHeader("Accept", "application/json")
                 if (basicAuthHeader != null) {
                     request.addHeader("Authorization", "Basic $basicAuthHeader")
                 }

--- a/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
@@ -62,6 +62,7 @@ internal interface TeamCityService {
     @GET("/app/rest/buildTypes/id:{id}/triggers")
     fun buildTypeTriggers(@Path("id") buildTypeId: String): TriggersBean
 
+    @Headers("Accept: application/json")
     @GET("/app/rest/buildTypes/id:{id}/artifact-dependencies")
     fun buildTypeArtifactDependencies(@Path("id") buildTypeId: String): ArtifactDependenciesBean
 


### PR DESCRIPTION
This header helps to avoid returning xml in response and then facing exception like [here](https://stackoverflow.com/questions/26290267/retrofit-removing-some-invalid-characters-from-response-body-before-parsing-it)