### PR TITLE
Fix invalid artifacts path - it should not be encoded

### DIFF
--- a/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
+++ b/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
@@ -40,11 +40,11 @@ internal interface TeamCityService {
 
     @Streaming
     @GET("/app/rest/builds/id:{id}/artifacts/content/{path}")
-    fun artifactContent(@Path("id") buildId: String, @Path("path") artifactPath: String): Response
+    fun artifactContent(@Path("id") buildId: String, @Path("path", encode = false) artifactPath: String): Response
 
     @Headers("Accept: application/json")
     @GET("/app/rest/builds/id:{id}/artifacts/children/{path}")
-    fun artifactChildren(@Path("id") buildId: String, @Path("path") artifactPath: String): ArtifactFileListBean
+    fun artifactChildren(@Path("id") buildId: String, @Path("path", encode = false) artifactPath: String): ArtifactFileListBean
 
     @Headers("Accept: application/json")
     @GET("/app/rest/projects/id:{id}")

--- a/src/test/kotlin/org.jetbrains.teamcity.rest/BuildTest.kt
+++ b/src/test/kotlin/org.jetbrains.teamcity.rest/BuildTest.kt
@@ -41,4 +41,14 @@ class BuildTest {
 
         build.fetchStatusText()
     }
+
+    @Test
+    fun test_get_artifacts() {
+        val build = publicInstance().builds()
+                .fromConfiguration(compilerAndPluginConfiguration)
+                .limitResults(1)
+                .list().first()
+
+        build.getArtifacts("maven/org")
+    }
 }


### PR DESCRIPTION
Artifact path was incorrectly encoded, which resulted into URL like

`https://teamcity.jetbrains.com/guestAuth/app/rest/builds/id:1111311/artifacts/children/maven%2Forg` 

which results into HTTP 400 error, instead of correct URL

`https://teamcity.jetbrains.com/guestAuth/app/rest/builds/id:1111311/artifacts/children/maven/org`

