### PR TITLE
Vcs properties

### DIFF
--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -222,6 +222,11 @@ interface VcsRoot {
     val name: String
 }
 
+interface VcsRootInstance {
+    val vcsRootId: VcsRootId
+    val name: String
+}
+
 enum class BuildStatus {
     SUCCESS,
     FAILURE,
@@ -236,7 +241,7 @@ interface PinInfo {
 interface Revision {
     val version: String
     val vcsBranchName: String
-    val vcsRoot: VcsRoot
+    val vcsRootInstance: VcsRootInstance
 }
 
 interface TriggeredInfo {

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -220,6 +220,13 @@ interface BuildArtifact {
 interface VcsRoot {
     val id: VcsRootId
     val name: String
+
+    fun fetchVcsRootProperties(): List<VcsRootProperty>
+}
+
+interface VcsRootProperty {
+    val name: String
+    val value: String
 }
 
 interface VcsRootInstance {

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -428,8 +428,8 @@ private class RevisionImpl(private val bean: RevisionBean) : Revision {
     override val vcsBranchName: String
         get() = bean.vcsBranchName!!
 
-    override val vcsRoot: VcsRoot
-        get() = VcsRootImpl(bean.`vcs-root-instance`!!)
+    override val vcsRootInstance: VcsRootInstance
+        get() = VcsRootInstanceImpl(bean.`vcs-root-instance`!!)
 }
 
 private data class BranchImpl(
@@ -580,6 +580,14 @@ private class VcsRootImpl(private val bean: VcsRootBean) : VcsRoot {
 
     override val id: VcsRootId
         get() = VcsRootId(bean.id!!)
+
+    override val name: String
+        get() = bean.name!!
+}
+
+private class VcsRootInstanceImpl(private val bean: VcsRootInstanceBean) : VcsRootInstance {
+    override val vcsRootId: VcsRootId
+        get() = VcsRootId(bean.`vcs-root-id`!!)
 
     override val name: String
         get() = bean.name!!

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
@@ -109,6 +109,11 @@ internal open class VcsRootBean {
     var name: String? = null
 }
 
+internal open class VcsRootInstanceBean {
+    var `vcs-root-id`: String? = null
+    var name: String? = null
+}
+
 internal class BuildListBean {
     var build: List<BuildBean> = ArrayList()
 }
@@ -249,5 +254,5 @@ internal class RevisionsBean {
 internal class RevisionBean {
     var version: String? = null
     var vcsBranchName: String? = null
-    var `vcs-root-instance`: VcsRootBean? = null
+    var `vcs-root-instance`: VcsRootInstanceBean? = null
 }

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
@@ -107,6 +107,8 @@ internal class VcsRootListBean {
 internal open class VcsRootBean {
     var id: String? = null
     var name: String? = null
+
+    var properties: VcsRootPropertiesBean? = null
 }
 
 internal open class VcsRootInstanceBean {
@@ -255,4 +257,13 @@ internal class RevisionBean {
     var version: String? = null
     var vcsBranchName: String? = null
     var `vcs-root-instance`: VcsRootInstanceBean? = null
+}
+
+internal class VcsRootPropertiesBean {
+    var property: List<VcsRootPropertyBean>? = ArrayList()
+}
+
+internal class VcsRootPropertyBean {
+    var name: String? = null
+    var value: String? = null
 }

--- a/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/VcsRootTest.kt
+++ b/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/VcsRootTest.kt
@@ -40,6 +40,13 @@ class VcsRootTest {
         assertNotNull("Vcs root should be loaded", vcsRoot)
     }
 
+    @Test
+    fun test_fetch_vcs_root_properties() {
+        val vcsRoot = vcsRootsFromPublicInstance().list().first()
+        val vcsRootProperties = vcsRoot.fetchVcsRootProperties()
+        assertNotNull("Vcs root properties should be loaded", vcsRootProperties)
+    }
+
     private fun vcsRootsFromPublicInstance(): VcsRootLocator {
         return publicInstance().vcsRoots()
     }


### PR DESCRIPTION
Hi guys,

this PR contributes the following two changes:

- Commit `Replace VcsRoot with VcsRootInstance in Revision`

The previously implemented `Revision` contained a `VcsRoot` having the field `id` holding a `VcsRootId`. This `id` was then filled with the value hold by the `id` attribute of the `vcs-root-instance` element (see an example xml below). This `id` however refers to an instance of a `VcsRoot` and not a `VcsRoot` itself. Thus, trying to access the vcs root under `/app/rest/vcs-roots/id:{id}` will not work.

This commit replaces the `VcsRoot` of a `Revision` with a `VcsRootInstance` having the value of the attribute `vcs-root-id` of the element `vcs-root-instance` as the `VcsRootId`.

```xml
...
<revisions count="1">
  <revision version="96bf990187e26d5637f1db8a820c1ed55b02b484" vcsBranchName="refs/heads/master">
    <vcs-root-instance id="32" vcs-root-id="vcs-root-id" name="vcs-root-name" href="/app/rest/vcs-root-instances/id:32"/>
  </revision>
</revisions>
...
```

- Commit `Fetch VcsRoot properties`

This commit provides the function `fetchVcsRootProperties()` for a `VcsRoot`. This enables, for example, to access the `url` of `VcsRoot` as the `name` of the `VcsRoot` might not always be the actual url.

```xml
<properties count="10">
  <property name="agentCleanFilesPolicy" value="ALL_UNTRACKED"/>
  <property name="agentCleanPolicy" value="ON_BRANCH_CHANGE"/>
  <property name="authMethod" value="ANONYMOUS"/>
  <property name="branch" value="refs/heads/master"/>
  <property name="ignoreKnownHosts" value="true"/>
  <property name="submoduleCheckout" value="CHECKOUT"/>
  <property name="teamcity:branchSpec" value="refs/heads/*"/>
  <property name="url" value="https://github.com/user/project-name"/>
  <property name="useAlternates" value="true"/>
  <property name="usernameStyle" value="USERID"/>
</properties>
```

Cheers,
Alex