### PR TITLE
Vcs properties accessors

### DIFF
--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -226,7 +226,7 @@ interface VcsRoot {
 
 interface VcsRootProperty {
     val name: String
-    val value: String
+    val value: String?
 }
 
 interface VcsRootInstance {

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -221,7 +221,8 @@ interface VcsRoot {
     val id: VcsRootId
     val name: String
 
-    fun fetchVcsRootProperties(): List<VcsRootProperty>
+    fun getUrl(): String?
+    fun getDefaultBranch(): String?
 }
 
 interface VcsRootProperty {

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -225,11 +225,6 @@ interface VcsRoot {
     fun getDefaultBranch(): String?
 }
 
-interface VcsRootProperty {
-    val name: String
-    val value: String?
-}
-
 interface VcsRootInstance {
     val vcsRootId: VcsRootId
     val name: String

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -590,7 +590,12 @@ private class VcsRootImpl(private val bean: VcsRootBean,
     val fullVcsRootBean: VcsRootBean by lazy {
         if (isFullVcsRootBean) bean else instance.service.vcsRoot(id.stringId)
     }
-    override fun fetchVcsRootProperties(): List<VcsRootProperty> = fullVcsRootBean.properties!!.property!!.map { VcsRootPropertyImpl(it) }
+
+    fun fetchVcsRootProperties(): List<VcsRootProperty> = fullVcsRootBean.properties!!.property!!.map { VcsRootPropertyImpl(it) }
+    fun getProperty(name: String): String? = fetchVcsRootProperties().filter { it.name == name}.single().value
+
+    override fun getUrl(): String? = getProperty("url")
+    override fun getDefaultBranch(): String? = getProperty("branch")
 }
 
 private class VcsRootInstanceImpl(private val bean: VcsRootInstanceBean) : VcsRootInstance {

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -605,8 +605,8 @@ private class VcsRootPropertyImpl(private val bean: VcsRootPropertyBean) : VcsRo
     override val name: String
         get() = bean.name!!
 
-    override val value: String
-        get() = bean.value!!
+    override val value: String?
+        get() = bean.value
 }
 
 private class BuildArtifactImpl(

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -591,11 +591,10 @@ private class VcsRootImpl(private val bean: VcsRootBean,
         if (isFullVcsRootBean) bean else instance.service.vcsRoot(id.stringId)
     }
 
-    fun fetchVcsRootProperties(): List<VcsRootProperty> = fullVcsRootBean.properties!!.property!!.map { VcsRootPropertyImpl(it) }
-    fun getProperty(name: String): String? = fetchVcsRootProperties().filter { it.name == name}.single().value
+    fun fetchNameValueProperties(): List<NameValueProperty> = fullVcsRootBean.properties!!.property!!.map { NameValueProperty(it) }
 
-    override fun getUrl(): String? = getProperty("url")
-    override fun getDefaultBranch(): String? = getProperty("branch")
+    override fun getUrl(): String? = getNameValueProperty(fetchNameValueProperties(), "url")
+    override fun getDefaultBranch(): String? = getNameValueProperty(fetchNameValueProperties(), "branch")
 }
 
 private class VcsRootInstanceImpl(private val bean: VcsRootInstanceBean) : VcsRootInstance {
@@ -606,11 +605,11 @@ private class VcsRootInstanceImpl(private val bean: VcsRootInstanceBean) : VcsRo
         get() = bean.name!!
 }
 
-private class VcsRootPropertyImpl(private val bean: VcsRootPropertyBean) : VcsRootProperty {
-    override val name: String
+private class NameValueProperty(private val bean: NameValuePropertyBean) {
+    val name: String
         get() = bean.name!!
 
-    override val value: String?
+    val value: String?
         get() = bean.value
 }
 
@@ -624,6 +623,8 @@ private class BuildArtifactImpl(
         build.downloadArtifact(fullName, output)
     }
 }
+
+private fun getNameValueProperty(properties: List<NameValueProperty>, name: String): String? = properties.filter { it.name == name}.single().value
 
 private fun convertToJavaRegexp(pattern: String): Regex {
     return pattern.replace(".", "\\.").replace("*", ".*").replace("?", ".").toRegex()

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
@@ -108,7 +108,7 @@ internal open class VcsRootBean {
     var id: String? = null
     var name: String? = null
 
-    var properties: VcsRootPropertiesBean? = null
+    var properties: NameValuePropertiesBean? = null
 }
 
 internal open class VcsRootInstanceBean {
@@ -259,11 +259,11 @@ internal class RevisionBean {
     var `vcs-root-instance`: VcsRootInstanceBean? = null
 }
 
-internal class VcsRootPropertiesBean {
-    var property: List<VcsRootPropertyBean>? = ArrayList()
+internal class NameValuePropertiesBean {
+    var property: List<NameValuePropertyBean>? = ArrayList()
 }
 
-internal class VcsRootPropertyBean {
+internal class NameValuePropertyBean {
     var name: String? = null
     var value: String? = null
 }

--- a/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/VcsRootTest.kt
+++ b/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/VcsRootTest.kt
@@ -41,10 +41,17 @@ class VcsRootTest {
     }
 
     @Test
-    fun test_fetch_vcs_root_properties() {
+    fun test_get_url() {
         val vcsRoot = vcsRootsFromPublicInstance().list().first()
-        val vcsRootProperties = vcsRoot.fetchVcsRootProperties()
-        assertNotNull("Vcs root properties should be loaded", vcsRootProperties)
+        val url = vcsRoot.getUrl()
+        assertNotNull("Vcs root url should be loaded", url)
+    }
+
+    @Test
+    fun test_get_default_branch() {
+        val vcsRoot = vcsRootsFromPublicInstance().list().first()
+        val url = vcsRoot.getDefaultBranch()
+        assertNotNull("Vcs root default branch should be loaded", url)
     }
 
     private fun vcsRootsFromPublicInstance(): VcsRootLocator {


### PR DESCRIPTION
Hi guys,

this PR refers to the suggestion of @chashnikov from PR GH-37 and contributes the following two changes:

- Commit `VcsRootProperty value could be null` 9db5c95

The value of a property of a `VcsRoot` may be null (e.g. `secure:password` of the following xml section).

```xml
...
<properties count="12">
  <property name="agentCleanFilesPolicy" value="ALL_UNTRACKED"/>
  <property name="agentCleanPolicy" value="ON_BRANCH_CHANGE"/>
  <property name="authMethod" value="PASSWORD"/>
  <property name="branch" value="refs/heads/master"/>
  <property name="ignoreKnownHosts" value="true"/>
  <property name="secure:password"/>
  <property name="submoduleCheckout" value="CHECKOUT"/>
  <property name="teamcity:branchSpec" value="refs/heads/*"/>
  <property name="url" value="https://github.com/alexscheitlin/projectname"/>
  <property name="useAlternates" value="true"/>
  <property name="username" value="alexscheitlin"/>
  <property name="usernameStyle" value="USERID"/>
</properties>
...
```

- Commit `Replace VcsRoot.fetchVcsRootProperties() with .getUrl() and .getDefaultBranch()` 
d437c08

To provide better access to `VcsRootProperties` specific accessors (e.g. `getUrl()` and `getDefaultBranch`) are used instead of `fetchVcsRootProperties`.

Cheers,
Alex