### PR TITLE
Update to TeamCityInstanceFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Client for TeamCity REST API written in Kotlin. The code snippet below will download `*.zip` artifacts from the latest successfull build with tag `publish` of the specified build configuration to `out` directory.
 ```kotlin
 val docs = BuildConfigurationId("Kotlin_StandardLibraryDocumentation")
-val build = TeamCityInstance.guestAuth("https://teamcity.jetbrains.com").builds()
+val build = TeamCityInstanceFactory.guestAuth("https://teamcity.jetbrains.com").builds()
                             .fromConfiguration(docs)
                             .withTag("publish")
                             .latest()


### PR DESCRIPTION
Hi guys,

I just updated the first example of the README as it still used the deprecated method `TeamCityInstance.guestAuth`.

When do you plan to publish the newest changes from the last few PR's to jcenter?

Cheers,
Alex