### PR TITLE
Support untilDate in BuildLocator

### DIFF
--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -134,6 +134,8 @@ interface BuildLocator {
 
     fun sinceDate(date: Date) : BuildLocator
 
+    fun untilDate(date: Date) : BuildLocator
+
     fun latest(): Build?
     fun all(): Sequence<Build>
 

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -230,6 +230,7 @@ private class BuildLocatorImpl(private val instance: TeamCityInstanceImpl) : Bui
     private var number: String? = null
     private var vcsRevision: String? = null
     private var sinceDate: Date? = null
+    private var untilDate: Date? = null
     private var status: BuildStatus? = BuildStatus.SUCCESS
     private var tags = ArrayList<String>()
     private var count: Int? = null
@@ -304,6 +305,11 @@ private class BuildLocatorImpl(private val instance: TeamCityInstanceImpl) : Bui
         return this
     }
 
+    override fun untilDate(date: Date): BuildLocator {
+        this.untilDate = date
+        return this
+    }
+
     override fun withAllBranches(): BuildLocator {
         if (branch != null) {
             LOG.warn("Branch is ignored because of #withAllBranches")
@@ -345,6 +351,7 @@ private class BuildLocatorImpl(private val instance: TeamCityInstanceImpl) : Bui
                 count1?.let { "count:$it" },
 
                 sinceDate?.let {"sinceDate:${teamCityServiceDateFormat.get().format(sinceDate)}"},
+                untilDate?.let {"untilDate:${teamCityServiceDateFormat.get().format(untilDate)}"},
 
                 if (!includeAllBranches)
                     branch?.let { "branch:$it" }

--- a/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/BuildTest.kt
+++ b/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/BuildTest.kt
@@ -21,20 +21,23 @@ class BuildTest {
 
         println(builds.joinToString("\n"))
     }
-    
+
     @Test
-    fun since_date() {
+    fun since_date_and_until_date() {
         val monthAgo = GregorianCalendar()
         monthAgo.add(Calendar.MONTH, -1)
-        
+        val weekAgo = GregorianCalendar()
+        monthAgo.add(Calendar.DAY_OF_MONTH, -7)
+
         val builds = publicInstance().builds()
                 .fromConfiguration(compileExamplesConfiguration)
                 .limitResults(3)
                 .sinceDate(monthAgo.time)
+                .untilDate(weekAgo.time)
                 .all()
 
         for (build in builds) {
-            assert(build.startDate!! >= monthAgo.time)
+            assert(build.startDate!! >= monthAgo.time && build.startDate!! <= weekAgo.time)
         }
     }
 


### PR DESCRIPTION
This commit adds an untilDate field in BuildLocator.

Fixes https://github.com/JetBrains/teamcity-rest-client/issues/51