### PR TITLE
Added support for 'buildId' in BuildLocator, added integration test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
 
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ buildscript {
 
     repositories {
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -92,6 +92,8 @@ interface UserLocator {
 interface BuildLocator {
     fun fromConfiguration(buildConfigurationId: BuildConfigurationId): BuildLocator
 
+    fun withBuildId(buildId: BuildId): BuildLocator
+
     fun withNumber(buildNumber: String): BuildLocator
 
     /**

--- a/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/BuildTest.kt
+++ b/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/BuildTest.kt
@@ -21,9 +21,24 @@ class BuildTest {
 
         println(builds.joinToString("\n"))
     }
-    
+
     @Test
-    fun since_date() {
+    fun test_build_id() {
+        val builds = publicInstance().builds()
+                .withBuildId(BuildId("1173662"))
+                .includeFailed()
+                .limitResults(1)
+                .all()
+
+        val build = builds.first()
+
+        assert(build.id.stringId                   == "1173662")
+        assert(build.buildConfigurationId.stringId == "bt345")
+        assert(build.status                        == BuildStatus.FAILURE)
+    }
+
+    @Test
+    fun test_since_date() {
         val monthAgo = GregorianCalendar()
         monthAgo.add(Calendar.MONTH, -1)
         
@@ -104,7 +119,7 @@ class BuildTest {
     }
 
     @Test
-    fun pagination() {
+    fun test_pagination() {
         val iterator = publicInstance().builds()
                 .fromConfiguration(KotlinDevBuildNumber)
                 .all()


### PR DESCRIPTION
The Kotlin API currently does not support specifying the `buildId` of the TC build itself.

Changes:
- added support for `buildId`
    - the `defaultFilter` is turned off in this case as integration test showed it was not working with default filter turned on