### PR TITLE
Adding support for finding artifact recursively

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ configure(project(':teamcity-rest-client-impl')) {
         compile 'org.slf4j:slf4j-api:1.7.12'
 
         testCompile 'junit:junit:4.12'
+        testCompile 'org.assertj:assertj-core:2.9.1'
         testCompile 'org.slf4j:slf4j-log4j12:1.7.12'
         testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -360,7 +360,7 @@ interface Build {
     fun pin(comment: String = "pinned via REST API")
     fun unpin(comment: String = "unpinned via REST API")
     fun getArtifacts(parentPath: String = "", recursive: Boolean = false, hidden: Boolean = false): List<BuildArtifact>
-    fun findArtifact(pattern: String, parentPath: String = ""): BuildArtifact
+    fun findArtifact(pattern: String, parentPath: String = "", recursive: Boolean = false): BuildArtifact
     fun downloadArtifacts(pattern: String, outputDir: File)
     fun downloadArtifact(artifactPath: String, output: OutputStream)
     fun downloadArtifact(artifactPath: String, output: File)

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -360,6 +360,7 @@ interface Build {
     fun pin(comment: String = "pinned via REST API")
     fun unpin(comment: String = "unpinned via REST API")
     fun getArtifacts(parentPath: String = "", recursive: Boolean = false, hidden: Boolean = false): List<BuildArtifact>
+    fun findArtifact(pattern: String, parentPath: String = ""): BuildArtifact
     fun findArtifact(pattern: String, parentPath: String = "", recursive: Boolean = false): BuildArtifact
     fun downloadArtifacts(pattern: String, outputDir: File)
     fun downloadArtifact(artifactPath: String, output: OutputStream)

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -1000,6 +1000,10 @@ private class BuildImpl(bean: BuildBean,
                 .map { BuildArtifactImpl(this, it.name!!, it.fullName!!, it.size, teamCityServiceDateFormat.get().parse(it.modificationTime!!)) }
     }
 
+    override fun findArtifact(pattern: String, parentPath: String): BuildArtifact {
+        return findArtifact(pattern, parentPath, false)
+    }
+
     override fun findArtifact(pattern: String, parentPath: String, recursive: Boolean): BuildArtifact {
         val list = getArtifacts(parentPath, recursive)
         val regexp = convertToJavaRegexp(pattern)

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -1000,8 +1000,8 @@ private class BuildImpl(bean: BuildBean,
                 .map { BuildArtifactImpl(this, it.name!!, it.fullName!!, it.size, teamCityServiceDateFormat.get().parse(it.modificationTime!!)) }
     }
 
-    override fun findArtifact(pattern: String, parentPath: String): BuildArtifact {
-        val list = getArtifacts(parentPath)
+    override fun findArtifact(pattern: String, parentPath: String, recursive: Boolean): BuildArtifact {
+        val list = getArtifacts(parentPath, recursive)
         val regexp = convertToJavaRegexp(pattern)
         val result = list.filter { regexp.matches(it.name) }
         if (result.isEmpty()) {


### PR DESCRIPTION
This is useful for Eclipse Kotlin plugin Ant to Gradle rewrite.

Notes:
1. Is there a better way to assert the exception message than the one in unit test?
2. Is this API change backwards compatible in Kotlin?
    - If so, do we care about not breaking Java clients?
    - The method called from Java will now contain 3 parameters which is API breaking change from Java's perspective.