### PR TITLE
fix JDK11 warning from older OkHttp3, use OkHttp4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,6 @@
-buildscript {
-    ext.kotlin_version = '1.3.21'
-
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
 plugins {
     id "com.jfrog.bintray" version "1.8.4"
+    id "org.jetbrains.kotlin.jvm" version "1.3.61"
 }
 
 allprojects {
@@ -23,7 +14,7 @@ allprojects {
 
 configure(project(':teamcity-rest-client-api')) {
     dependencies {
-        compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+        compile "org.jetbrains.kotlin:kotlin-stdlib"
     }
 }
 
@@ -31,16 +22,17 @@ configure(project(':teamcity-rest-client-impl')) {
     dependencies {
         compile "commons-codec:commons-codec:1.10"
         compile 'com.squareup.retrofit:retrofit:1.9.0'
+        compile "com.squareup.okhttp3:okhttp:4.3.1"
         compile 'com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0'
-        compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+        compile "org.jetbrains.kotlin:kotlin-stdlib"
 
         compile 'org.slf4j:slf4j-api:1.7.12'
 
         testCompile 'junit:junit:4.12'
         testCompile 'org.assertj:assertj-core:3.12.2'
         testCompile 'org.slf4j:slf4j-log4j12:1.7.12'
-        testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-        testCompile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+        testCompile "org.jetbrains.kotlin:kotlin-test"
+        testCompile "org.jetbrains.kotlin:kotlin-reflect"
 
         compile project(':teamcity-rest-client-api')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,6 @@ if (hasProperty("bintrayUser")) {
 }
 
 wrapper {
-  gradleVersion = '5.2'
+  gradleVersion = '6.1.1'
   distributionUrl = "https://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "com.jfrog.bintray" version "1.8.4"
-    id "org.jetbrains.kotlin.jvm" version "1.3.61"
+    id "org.jetbrains.kotlin.jvm" version "1.3.71"
 }
 
 allprojects {
@@ -14,7 +14,7 @@ allprojects {
 
 configure(project(':teamcity-rest-client-api')) {
     dependencies {
-        compile "org.jetbrains.kotlin:kotlin-stdlib"
+        compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     }
 }
 
@@ -24,7 +24,7 @@ configure(project(':teamcity-rest-client-impl')) {
         compile 'com.squareup.retrofit:retrofit:1.9.0'
         compile "com.squareup.okhttp3:okhttp:4.3.1"
         compile 'com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0'
-        compile "org.jetbrains.kotlin:kotlin-stdlib"
+        compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
         compile 'org.slf4j:slf4j-api:1.7.12'
 
@@ -112,6 +112,17 @@ if (hasProperty("bintrayUser")) {
                 name = project.version
             }
         }
+    }
+}
+
+subprojects {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions { jvmTarget = '1.8' }
+    }
+
+    compileJava {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,8 @@ configure(project(':teamcity-rest-client-api')) {
 
 configure(project(':teamcity-rest-client-impl')) {
     dependencies {
-        compile "commons-codec:commons-codec:1.10"
         compile 'com.squareup.retrofit:retrofit:1.9.0'
-        compile "com.squareup.okhttp3:okhttp:4.3.1"
+        compile "com.squareup.okhttp3:okhttp:4.7.2"
         compile 'com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0'
         compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-5.2-all.zip
+distributionUrl=https\://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-6.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -9,7 +9,7 @@ import java.time.ZonedDateTime
 import java.util.*
 import java.util.concurrent.TimeUnit
 
-abstract class TeamCityInstance {
+abstract class TeamCityInstance : AutoCloseable {
     abstract val serverUrl: String
 
     abstract fun withLogResponses(): TeamCityInstance

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -149,8 +149,10 @@ internal class TeamCityInstanceImpl(override val serverUrl: String,
             .create(TeamCityService::class.java)
 
     override fun close() {
-        client.connectionPool.evictAll()
         client.dispatcher.cancelAll()
+        client.dispatcher.executorService.shutdown()
+        client.connectionPool.evictAll()
+        client.cache?.close()
     }
 
     override fun builds(): BuildLocator = BuildLocatorImpl(this)

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -8,7 +8,6 @@ import okhttp3.Dispatcher
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Response
-import org.apache.commons.codec.binary.Base64
 import org.slf4j.LoggerFactory
 import retrofit.RestAdapter
 import retrofit.converter.GsonConverter
@@ -41,7 +40,7 @@ internal fun createGuestAuthInstance(serverUrl: String): TeamCityInstanceImpl {
 }
 
 internal fun createHttpAuthInstance(serverUrl: String, username: String, password: String): TeamCityInstanceImpl {
-    val authorization = Base64.encodeBase64String("$username:$password".toByteArray())
+    val authorization = Base64.getEncoder().encodeToString("$username:$password".toByteArray())
     return TeamCityInstanceImpl(serverUrl.trimEnd('/'), "/httpAuth", "Basic $authorization", false)
 }
 

--- a/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/ShutdownTest.kt
+++ b/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/ShutdownTest.kt
@@ -1,8 +1,12 @@
 package org.jetbrains.teamcity.rest
 
+import org.junit.Before
 import org.junit.Test
 
 class ShutdownTest {
+    @Before
+    fun setupLog4j() = setupLog4jDebug()
+
     @Test
     fun testEmpty() {
         publicInstance().close()

--- a/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/ShutdownTest.kt
+++ b/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/ShutdownTest.kt
@@ -1,0 +1,17 @@
+package org.jetbrains.teamcity.rest
+
+import org.junit.Test
+
+class ShutdownTest {
+    @Test
+    fun testEmpty() {
+        publicInstance().close()
+    }
+
+    @Test
+    fun testUsed() {
+        publicInstance().use {
+            it.rootProject()
+        }
+    }
+}


### PR DESCRIPTION
update Kotlin to 1.3.61, simplify Gradle script

OkHttp4 is binary compatible to OkHttp3, the update does not require
changing other dependencies and Retrofit