### PR TITLE
Allow to filter TestRun fields and to turn off defaultFilter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-projectVersion=1.9
+projectVersion=1.10

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -144,6 +144,8 @@ interface BuildLocator {
      */
     fun withAllBranches(): BuildLocator
 
+    fun withDefaultFilter(enabled: Boolean): BuildLocator
+
     fun pinnedOnly(): BuildLocator
 
     fun includePersonal() : BuildLocator

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -189,6 +189,20 @@ interface TestRunsLocator {
     fun forProject(projectId: ProjectId): TestRunsLocator
     fun withStatus(testStatus: TestStatus): TestRunsLocator
     fun all(): Sequence<TestRun>
+    fun all(fields: EnumSet<TestRunFields>): Sequence<TestRun>
+}
+
+enum class TestRunFields {
+    Name,
+    Status,
+    Ignored,
+    Duration,
+    IgnoreDetails,
+    Details,
+    CurrentlyMuted,
+    Muted,
+    Build,
+    Test
 }
 
 data class ProjectId(val stringId: String) {

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -526,7 +526,11 @@ private class TestRunsLocatorImpl(private val instance: TeamCityInstanceImpl) : 
         return this
     }
 
-    override fun all(): Sequence<TestRun> {
+    override fun all(): Sequence<TestRun> = allImpl(TestOccurrenceBean.filter)
+
+    override fun all(fields: EnumSet<TestRunFields>): Sequence<TestRun> = allImpl(TestOccurrenceBean.toFilterString(fields))
+
+    private fun allImpl(testOccurrenceFieldsFilter: String) : Sequence<TestRun> {
         val statusLocator = when (testStatus) {
             null -> null
             TestStatus.FAILED -> "status:FAILURE"

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
@@ -5,6 +5,7 @@ package org.jetbrains.teamcity.rest
 import retrofit.client.Response
 import retrofit.http.*
 import retrofit.mime.TypedString
+import java.util.*
 import kotlin.collections.ArrayList
 
 internal interface TeamCityService {
@@ -523,7 +524,25 @@ internal open class TestOccurrenceBean {
     var test: TestBean? = null
 
     companion object {
-        val filter = "testOccurrence(name,status,ignored,muted,currentlyMuted,duration,ignoreDetails,details,build(id),test(id))"
+        val filter = toFilterString(EnumSet.allOf(TestRunFields::class.java))
+
+        fun toFilterString(fields: EnumSet<TestRunFields>): String {
+            val sb = StringBuilder("testOccurrence(")
+            when {
+                fields.contains(TestRunFields.Build) -> sb.append("build(id)")
+                fields.contains(TestRunFields.CurrentlyMuted) -> sb.append("currentlyMuted")
+                fields.contains(TestRunFields.Details) -> sb.append("details")
+                fields.contains(TestRunFields.Duration) -> sb.append("duration")
+                fields.contains(TestRunFields.IgnoreDetails) -> sb.append("ignoreDetails")
+                fields.contains(TestRunFields.Ignored) -> sb.append("ignored")
+                fields.contains(TestRunFields.Muted) -> sb.append("muted")
+                fields.contains(TestRunFields.Name) -> sb.append("name")
+                fields.contains(TestRunFields.Status) -> sb.append("status")
+                fields.contains(TestRunFields.Test) -> sb.append("test(id)")
+            }
+            sb.append(")")
+            return sb.toString()
+        }
     }
 }
 

--- a/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/TestsTest.kt
+++ b/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/TestsTest.kt
@@ -11,6 +11,7 @@ class TestsTest {
 
     @Test
     fun test_deprecated_list_tests() {
+        @Suppress("DEPRECATION")
         val tests = publicInstance().builds()
                 .fromConfiguration(runTestsBuildConfiguration)
                 .limitResults(3)


### PR DESCRIPTION
* The details of the test run can be extremely large and are not always needed, so now it's possible to opt out of requesting them from server
* The defaultFilter hides some builds and there was no way to find them previously