### PR TITLE
added possibility to ask for expanded invocations of testruns

### DIFF
--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -188,9 +188,12 @@ interface TestRunsLocator {
     fun withStatus(testStatus: TestStatus): TestRunsLocator
 
     /**
-     * By default only one test run is returned. Set to true to return all invocations of test in run.
+     * If expandMultipleInvocations is enabled, individual runs of tests, which were executed several
+     * times in same build, are returned as separate entries.
+     * By default such runs are aggregated into a single value, duration property will be the sum of durations
+     * of individual runs, and status will be SUCCESSFUL if and only if all runs are successful.
      */
-    fun expandInvocations() : TestRunsLocator
+    fun expandMultipleInvocations() : TestRunsLocator
     fun all(): Sequence<TestRun>
 }
 

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -190,7 +190,7 @@ interface TestRunsLocator {
     /**
      * By default only one test run is returned. Set to true to return all invocations of test in run.
      */
-    fun withExpandInvocations(expandInvocations: Boolean) : TestRunsLocator
+    fun expandInvocations() : TestRunsLocator
     fun all(): Sequence<TestRun>
 }
 

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -186,6 +186,10 @@ interface TestRunsLocator {
     fun forTest(testId: TestId): TestRunsLocator
     fun forProject(projectId: ProjectId): TestRunsLocator
     fun withStatus(testStatus: TestStatus): TestRunsLocator
+
+    /**
+     * By default only one test run is returned. Set to true to return all invocations of test in run.
+     */
     fun withExpandInvocations(expandInvocations: Boolean) : TestRunsLocator
     fun all(): Sequence<TestRun>
 }

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -186,6 +186,7 @@ interface TestRunsLocator {
     fun forTest(testId: TestId): TestRunsLocator
     fun forProject(projectId: ProjectId): TestRunsLocator
     fun withStatus(testStatus: TestStatus): TestRunsLocator
+    fun withExpandInvocations(expandInvocations: Boolean) : TestRunsLocator
     fun all(): Sequence<TestRun>
 }
 

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -489,7 +489,7 @@ private class TestRunsLocatorImpl(private val instance: TeamCityInstanceImpl) : 
     private var testId: TestId? = null
     private var affectedProjectId: ProjectId? = null
     private var testStatus: TestStatus? = null
-    private var expandInvocations: Boolean? = null
+    private var expandInvocations = false
 
     override fun limitResults(count: Int): TestRunsLocator {
         this.limitResults = count
@@ -521,8 +521,8 @@ private class TestRunsLocatorImpl(private val instance: TeamCityInstanceImpl) : 
         return this
     }
 
-    override fun withExpandInvocations(expandInvocations: Boolean): TestRunsLocator {
-        this.expandInvocations = expandInvocations
+    override fun expandInvocations(): TestRunsLocator {
+        this.expandInvocations = true
         return this
     }
 
@@ -541,7 +541,7 @@ private class TestRunsLocatorImpl(private val instance: TeamCityInstanceImpl) : 
                 affectedProjectId?.let { "affectedProject:$it" },
                 buildId?.let { "build:$it" },
                 testId?.let { "test:$it" },
-                expandInvocations?.let { "expandInvocations:$it" },
+                expandInvocations.let { "expandInvocations:$it" },
                 statusLocator
         )
 

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -489,7 +489,7 @@ private class TestRunsLocatorImpl(private val instance: TeamCityInstanceImpl) : 
     private var testId: TestId? = null
     private var affectedProjectId: ProjectId? = null
     private var testStatus: TestStatus? = null
-    private var expandInvocations = false
+    private var expandMultipleInvocations = false
 
     override fun limitResults(count: Int): TestRunsLocator {
         this.limitResults = count
@@ -521,8 +521,8 @@ private class TestRunsLocatorImpl(private val instance: TeamCityInstanceImpl) : 
         return this
     }
 
-    override fun expandInvocations(): TestRunsLocator {
-        this.expandInvocations = true
+    override fun expandMultipleInvocations(): TestRunsLocator {
+        this.expandMultipleInvocations = true
         return this
     }
 
@@ -541,7 +541,7 @@ private class TestRunsLocatorImpl(private val instance: TeamCityInstanceImpl) : 
                 affectedProjectId?.let { "affectedProject:$it" },
                 buildId?.let { "build:$it" },
                 testId?.let { "test:$it" },
-                expandInvocations.let { "expandInvocations:$it" },
+                expandMultipleInvocations.let { "expandInvocations:$it" },
                 statusLocator
         )
 

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -489,6 +489,7 @@ private class TestRunsLocatorImpl(private val instance: TeamCityInstanceImpl) : 
     private var testId: TestId? = null
     private var affectedProjectId: ProjectId? = null
     private var testStatus: TestStatus? = null
+    private var expandInvocations: Boolean? = null
 
     override fun limitResults(count: Int): TestRunsLocator {
         this.limitResults = count
@@ -520,6 +521,11 @@ private class TestRunsLocatorImpl(private val instance: TeamCityInstanceImpl) : 
         return this
     }
 
+    override fun withExpandInvocations(expandInvocations: Boolean): TestRunsLocator {
+        this.expandInvocations = expandInvocations
+        return this
+    }
+
     override fun all(): Sequence<TestRun> {
         val statusLocator = when (testStatus) {
             null -> null
@@ -535,6 +541,7 @@ private class TestRunsLocatorImpl(private val instance: TeamCityInstanceImpl) : 
                 affectedProjectId?.let { "affectedProject:$it" },
                 buildId?.let { "build:$it" },
                 testId?.let { "test:$it" },
+                expandInvocations?.let { "expandInvocations:$it" },
                 statusLocator
         )
 


### PR DESCRIPTION
Added support to list all test runs with all the invocations flattened

GET http://teamcity:8111/app/rest/testOccurrences?locator=build:(id:XXX),test:(id:XXX),expandInvocations:true
