### PR TITLE
Fix not passing agentId param in runBuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to teamcity-rest-client library will be documented in this file.
 
+## [1.17.1] - 2021-12-06
+
+### Changed
+
+- Fix not passing agentId param in deprecated `BuildConfiguration::runBuild` method overload.
+
 ## [1.17.0] - 2021-12-02
 
 ### Added

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -924,7 +924,7 @@ private class BuildConfigurationImpl(bean: BuildTypeBean,
                           agentId: String?,
                           personal: Boolean): Build {
         return runBuild(parameters, queueAtTop, cleanSources, rebuildAllDependencies,
-            comment, logicalBranchName, null, personal, null, null)
+            comment, logicalBranchName, agentId, personal, null, null)
     }
 
     override fun runBuild(


### PR DESCRIPTION
Fix not passing agentId param in deprecated `BuildConfiguration::runBuild` method overload.