### PR TITLE
Add support for the Mutes

### DIFF
--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -19,6 +19,8 @@ abstract class TeamCityInstance : AutoCloseable {
     abstract fun investigations(): InvestigationLocator
 
     abstract fun mutes(): MuteLocator
+
+    abstract fun tests(): TestLocator
     abstract fun build(id: BuildId): Build
     abstract fun build(buildConfigurationId: BuildConfigurationId, number: String): Build?
     abstract fun buildConfiguration(id: BuildConfigurationId): BuildConfiguration
@@ -188,9 +190,17 @@ interface MuteLocator {
     fun limitResults(count: Int): MuteLocator
     fun forProject(projectId: ProjectId): MuteLocator
     fun byUser(userId: UserId): MuteLocator
-
     fun forTest(testId: TestId): MuteLocator
     fun all(): Sequence<Mute>
+}
+
+interface TestLocator {
+    fun limitResults(count: Int): TestLocator
+    fun byId(testId: TestId): TestLocator
+    fun byName(testName: String): TestLocator
+    fun currentlyMuted(muted: Boolean): TestLocator
+    fun forProject(projectId: ProjectId): TestLocator
+    fun all(): Sequence<Test>
 }
 
 interface TestRunsLocator {
@@ -557,7 +567,7 @@ interface Investigation {
 
 interface Mute {
     val id: InvestigationId
-    val assignee: User
+    val assignee: User?
     val reporter: User?
     val comment: String
     val resolveMethod: InvestigationResolveMethod
@@ -568,11 +578,9 @@ interface Mute {
     val tests: List<Test>?
 }
 
-/**
- * Data class to store Test data, to be replaced with API to handle requests to the tests
- */
-data class Test(val id: String, val name: String) {
-    override fun toString(): String = id
+interface Test {
+    val id: TestId
+    val name: String
 }
 
 interface BuildRunningInfo {

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -539,6 +539,10 @@ interface Build {
     val finishDate: Date?
 }
 
+/**
+ * Interface for the common part of mutes and investigations, which are action points for the problem.
+ * Use Investigation or Mute interfaces accordingly
+ */
 interface InvestigationMuteBase {
     val id: InvestigationId
     val assignee: User
@@ -555,7 +559,16 @@ interface Investigation : InvestigationMuteBase {
     val state: InvestigationState
 }
 
-interface Mute : InvestigationMuteBase
+interface Mute : InvestigationMuteBase {
+    val tests: List<Test>?
+}
+
+/**
+ * Data class to store Test data, to be replaced with API to handle requests to the tests
+ */
+data class Test(val id: String, val name: String) {
+    override fun toString(): String = id
+}
 
 interface BuildRunningInfo {
     val percentageComplete: Int

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -539,11 +539,7 @@ interface Build {
     val finishDate: Date?
 }
 
-/**
- * Interface for the common part of mutes and investigations, which are action points for the problem.
- * Use Investigation or Mute interfaces accordingly
- */
-interface InvestigationMuteBase {
+interface Investigation {
     val id: InvestigationId
     val assignee: User
     val reporter: User?
@@ -553,13 +549,19 @@ interface InvestigationMuteBase {
     val testIds: List<TestId>?
     val problemIds: List<BuildProblemId>?
     val scope: InvestigationScope
-}
-
-interface Investigation : InvestigationMuteBase {
     val state: InvestigationState
 }
 
-interface Mute : InvestigationMuteBase {
+interface Mute {
+    val id: InvestigationId
+    val assignee: User
+    val reporter: User?
+    val comment: String
+    val resolveMethod: InvestigationResolveMethod
+    val targetType: InvestigationTargetType
+    val testIds: List<TestId>?
+    val problemIds: List<BuildProblemId>?
+    val scope: InvestigationScope
     val tests: List<Test>?
 }
 

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -187,6 +187,9 @@ interface InvestigationLocator {
 interface MuteLocator {
     fun limitResults(count: Int): MuteLocator
     fun forProject(projectId: ProjectId): MuteLocator
+    fun byUser(userId: UserId): MuteLocator
+
+    fun forTest(testId: TestId): MuteLocator
     fun all(): Sequence<Mute>
 }
 

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -18,6 +18,7 @@ abstract class TeamCityInstance : AutoCloseable {
     abstract fun builds(): BuildLocator
     abstract fun investigations(): InvestigationLocator
 
+    abstract fun mutes(): MuteLocator
     abstract fun build(id: BuildId): Build
     abstract fun build(buildConfigurationId: BuildConfigurationId, number: String): Build?
     abstract fun buildConfiguration(id: BuildConfigurationId): BuildConfiguration
@@ -181,6 +182,12 @@ interface InvestigationLocator {
     fun forProject(projectId: ProjectId): InvestigationLocator
     fun withTargetType(targetType: InvestigationTargetType): InvestigationLocator
     fun all(): Sequence<Investigation>
+}
+
+interface MuteLocator {
+    fun limitResults(count: Int): MuteLocator
+    fun forProject(projectId: ProjectId): MuteLocator
+    fun all(): Sequence<Mute>
 }
 
 interface TestRunsLocator {
@@ -532,9 +539,8 @@ interface Build {
     val finishDate: Date?
 }
 
-interface Investigation {
+interface InvestigationMuteBase {
     val id: InvestigationId
-    val state: InvestigationState
     val assignee: User
     val reporter: User?
     val comment: String
@@ -544,6 +550,12 @@ interface Investigation {
     val problemIds: List<BuildProblemId>?
     val scope: InvestigationScope
 }
+
+interface Investigation : InvestigationMuteBase {
+    val state: InvestigationState
+}
+
+interface Mute : InvestigationMuteBase
 
 interface BuildRunningInfo {
     val percentageComplete: Int

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -706,19 +706,19 @@ private abstract class InvestigationMuteBaseImpl<TBean : InvestigationMuteBaseBe
     bean: TBean,
     isFullProjectBean: Boolean,
     instance: TeamCityInstanceImpl) :
-    BaseImpl<TBean>(bean, isFullProjectBean, instance), InvestigationMuteBase {
-    override val id: InvestigationId
+    BaseImpl<TBean>(bean, isFullProjectBean, instance) {
+    val id: InvestigationId
         get() = InvestigationId(idString)
 
-    override val reporter: User?
+    val reporter: User?
         get() {
             val assignment = nullable { it.assignment } ?: return null
             val userBean = assignment.user ?: return null
             return UserImpl( userBean, false, instance)
         }
-    override val comment: String
+    val comment: String
         get() = notNull { it.assignment?.text ?: "" }
-    override val resolveMethod: InvestigationResolveMethod
+    val resolveMethod: InvestigationResolveMethod
         get() {
             val asString = notNull { it.resolution?.type }
             if (asString == "whenFixed") {
@@ -729,7 +729,7 @@ private abstract class InvestigationMuteBaseImpl<TBean : InvestigationMuteBaseBe
 
             throw IllegalStateException("Properties are invalid")
         }
-    override val targetType: InvestigationTargetType
+    val targetType: InvestigationTargetType
         get() {
             val target = notNull { it.target}
             if (target.tests != null) return InvestigationTargetType.TEST
@@ -737,13 +737,13 @@ private abstract class InvestigationMuteBaseImpl<TBean : InvestigationMuteBaseBe
             return InvestigationTargetType.BUILD_CONFIGURATION
         }
 
-    override val testIds: List<TestId>?
+    val testIds: List<TestId>?
         get() = nullable { it.target?.tests?.test?.map { x -> TestId(notNull { x.id })} }
 
-    override val problemIds: List<BuildProblemId>?
+    val problemIds: List<BuildProblemId>?
         get() = nullable { it.target?.problems?.problem?.map { x -> BuildProblemId(notNull { x.id })} }
 
-    override val scope: InvestigationScope
+    val scope: InvestigationScope
         get() {
             val scope = notNull { it.scope }
             val project = scope.project?.let { bean -> ProjectImpl(bean, false, instance) }

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -546,6 +546,8 @@ private class InvestigationLocatorImpl(private val instance: TeamCityInstanceImp
 
 private class MuteLocatorImpl(private val instance: TeamCityInstanceImpl) : MuteLocator {
     private var limitResults: Int? = null
+    private var reporter: UserId? = null
+    private var test: TestId? = null
     private var affectedProjectId: ProjectId? = null
 
     override fun limitResults(count: Int): MuteLocator {
@@ -557,12 +559,24 @@ private class MuteLocatorImpl(private val instance: TeamCityInstanceImpl) : Mute
         return this
     }
 
+    override fun byUser(userId: UserId): MuteLocator {
+        this.reporter = userId
+        return this
+    }
+
+    override fun forTest(testId: TestId): MuteLocator {
+        this.test = testId
+        return this
+    }
+
     override fun all(): Sequence<Mute> {
         var muteLocator : String? = null
 
         val parameters = listOfNotNull(
             limitResults?.let { "count:$it" },
-            affectedProjectId?.let { "affectedProject:$it" }
+            affectedProjectId?.let { "affectedProject:$it" },
+            reporter?.let { "reporter:$it" },
+            test?.let { "test:$it" }
         )
 
         if (parameters.isNotEmpty()) {

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/implementation.kt
@@ -709,8 +709,7 @@ private abstract class InvestigationMuteBaseImpl<TBean : InvestigationMuteBaseBe
     BaseImpl<TBean>(bean, isFullProjectBean, instance), InvestigationMuteBase {
     override val id: InvestigationId
         get() = InvestigationId(idString)
-    override val assignee: User
-        get() = UserImpl( notNull { it.assignee }, false, instance)
+
     override val reporter: User?
         get() {
             val assignment = nullable { it.assignment } ?: return null
@@ -774,6 +773,9 @@ private class InvestigationImpl(
 
     override fun toString(): String = "Investigation(id=$idString,state=$state)"
 
+    override val assignee: User
+        get() = UserImpl( notNull { it.assignee }, false, instance)
+
     override val state: InvestigationState
         get() = notNull { it.state }
 
@@ -784,6 +786,12 @@ private class MuteImpl(
     isFullProjectBean: Boolean,
     instance: TeamCityInstanceImpl) :
     InvestigationMuteBaseImpl<MuteBean>(bean, isFullProjectBean, instance), Mute {
+
+    override val tests: List<Test>?
+        get() = nullable { it.target?.tests?.test?.map { testBean -> Test(notNull { testBean.id }, notNull { testBean.name } )} }
+
+    override val assignee: User
+        get() = UserImpl( notNull { it.assignment?.user }, false, instance)
 
     override fun fetchFullBean(): MuteBean = instance.service.mute(id.stringId)
 

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
@@ -562,6 +562,7 @@ internal open class TestOccurrencesBean {
 
 internal open class TestBean {
     var id: String? = null
+    var name: String? = null
 }
 
 internal open class TestOccurrenceBean {
@@ -592,7 +593,6 @@ internal class MuteListBean {
 }
 
 internal open class InvestigationMuteBaseBean: IdBean() {
-    val assignee: UserBean? = null
     val assignment: AssignmentBean? = null
     val resolution: InvestigationResolutionBean? = null
     val scope: InvestigationScopeBean? = null
@@ -605,6 +605,7 @@ internal class InvestigationListBean {
 }
 
 internal class InvestigationBean : InvestigationMuteBaseBean() {
+    val assignee: UserBean? = null
     val state: InvestigationState? = null
 }
 

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
@@ -31,6 +31,14 @@ internal interface TeamCityService {
     fun investigations(@Query("locator") investigationLocator: String?): InvestigationListBean
 
     @Headers("Accept: application/json")
+    @GET("/app/rest/tests")
+    fun tests(@Query("locator") locator: String?): TestListBean
+
+    @Headers("Accept: application/json")
+    @GET("/app/rest/tests/id:{id}")
+    fun test(@Path("id") id: String): TestBean
+
+    @Headers("Accept: application/json")
     @GET("/app/rest/investigations/id:{id}")
     fun investigation(@Path("id") id: String): InvestigationBean
 
@@ -39,7 +47,7 @@ internal interface TeamCityService {
     fun mutes(@Query("locator") muteLocator: String?): MuteListBean
 
     @Headers("Accept: application/json")
-    @GET("/app/rest/mutes")
+    @GET("/app/rest/mutes/id:{id}")
     fun mute(@Path("id") id: String): MuteBean
 
     @Headers("Accept: application/json")
@@ -559,9 +567,10 @@ internal open class TestOccurrencesBean {
     var nextHref: String? = null
     var testOccurrence: List<TestOccurrenceBean> = ArrayList()
 }
-
-internal open class TestBean {
-    var id: String? = null
+internal class TestListBean {
+    var test: List<TestBean> = ArrayList()
+}
+internal open class TestBean: IdBean() {
     var name: String? = null
 }
 

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
@@ -35,6 +35,14 @@ internal interface TeamCityService {
     fun investigation(@Path("id") id: String): InvestigationBean
 
     @Headers("Accept: application/json")
+    @GET("/app/rest/mutes")
+    fun mutes(@Query("locator") muteLocator: String?): MuteListBean
+
+    @Headers("Accept: application/json")
+    @GET("/app/rest/mutes")
+    fun mute(@Path("id") id: String): MuteBean
+
+    @Headers("Accept: application/json")
     @GET("/app/rest/changes")
     fun changes(@Query("locator") locator: String, @Query("fields") fields: String): ChangesBean
 
@@ -579,17 +587,25 @@ internal open class TestOccurrenceBean {
     }
 }
 
-internal class InvestigationListBean {
-    var investigation: List<InvestigationBean> = ArrayList()
+internal class MuteListBean {
+    var mute: List<MuteBean> = ArrayList()
 }
 
-internal class InvestigationBean: IdBean() {
-    val state: InvestigationState? = null
+internal open class InvestigationMuteBaseBean: IdBean() {
     val assignee: UserBean? = null
     val assignment: AssignmentBean? = null
     val resolution: InvestigationResolutionBean? = null
     val scope: InvestigationScopeBean? = null
     val target: InvestigationTargetBean? = null
+}
+internal class MuteBean : InvestigationMuteBaseBean()
+
+internal class InvestigationListBean {
+    var investigation: List<InvestigationBean> = ArrayList()
+}
+
+internal class InvestigationBean : InvestigationMuteBaseBean() {
+    val state: InvestigationState? = null
 }
 
 class InvestigationResolutionBean {

--- a/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/MuteTest.kt
+++ b/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/MuteTest.kt
@@ -13,12 +13,15 @@ class MuteTest {
     @Test
     fun test_assignment() {
         var hasAtLeastOneComment = false
+        var hasAtLeastOneAssignee = false
         val mutes = publicInstance().mutes().limitResults(10).all()
         for (mute in mutes) {
             with(mute) {
-                Assert.assertNotNull(assignee)
-                Assert.assertNotNull(assignee.id)
-                Assert.assertNotNull(assignee.username)
+                if(assignee != null) {
+                    Assert.assertNotNull(assignee!!.id)
+                    Assert.assertNotNull(assignee!!.username)
+                    hasAtLeastOneAssignee = true
+                }
                 if (comment.isNotEmpty()) {
                     hasAtLeastOneComment = true
                 }
@@ -26,6 +29,7 @@ class MuteTest {
         }
 
         Assert.assertTrue("No mutes with non-empty comment found", hasAtLeastOneComment)
+        Assert.assertTrue("No mutes with assignee found", hasAtLeastOneAssignee)
     }
 
     @Test
@@ -69,7 +73,7 @@ class MuteTest {
 
     @Test
     fun test_forProject() {
-        val filteredMutes = publicInstance().mutes().forProject(ProjectId("ProjectForSidebarCounters")).all()
+        val filteredMutes = publicInstance().mutes().forProject(testProject).all()
         val allMutes = publicInstance().mutes().all()
         Assert.assertTrue("No filtered mutes were found, whereas expected", filteredMutes.count() > 0)
         Assert.assertTrue("Number of filtered mutes is more or same as all mutes", filteredMutes.count() < allMutes.count())

--- a/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/TestsTest.kt
+++ b/teamcity-rest-client-impl/src/test/kotlin/org/jetbrains/teamcity/rest/TestsTest.kt
@@ -1,7 +1,9 @@
 package org.jetbrains.teamcity.rest
 
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertTrue
 
 class TestsTest {
     @Before
@@ -31,5 +33,18 @@ class TestsTest {
 
         println("Total tests: ${tests.size}")
         println(tests.joinToString("\n"))
+    }
+
+    @Test
+    fun test_get_tests() {
+        var tests = publicInstance().tests().forProject(testProject)
+            .currentlyMuted(true)
+            .limitResults(3)
+            .all().toList()
+        Assert.assertTrue( "No tests were provided for the test project", tests.isNotEmpty())
+        val testId = tests.first().id
+        tests = publicInstance().tests().byId(testId).all().toList()
+        Assert.assertTrue( "Not exactly one test found by ID $testId, found: ${tests.size}", tests.size == 1)
+        Assert.assertNotNull("test name is not set for the test with id $testId", tests.first().name)
     }
 }


### PR DESCRIPTION
We miss support if the mutes in the API. This PR adds support for requesting mutes and getting necessary information.

Our use-case would be to use these API calls to gather mutes from the TC and process them, including adding comments into the project code, in case test gets disabled there.

Tested by replacing `publicInstance` with the TC instance with token auth.

See [RIDER-90544](https://youtrack.jetbrains.com/issue/RIDER-90544).