### PR TITLE
Add ability to fetch test occurrence without 'details' field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to teamcity-rest-client library will be documented in this file.
 
+## [1.19.0] - 2023-05-05
+
+### Added
+
+- Add ability to fetch test occurrences without 'details' field.
+
+
 ## [1.17.1] - 2021-12-06
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-projectVersion=1.18
+projectVersion=1.19

--- a/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
+++ b/teamcity-rest-client-api/src/main/kotlin/org/jetbrains/teamcity/rest/api.kt
@@ -190,6 +190,7 @@ interface TestRunsLocator {
     fun forTest(testId: TestId): TestRunsLocator
     fun forProject(projectId: ProjectId): TestRunsLocator
     fun withStatus(testStatus: TestStatus): TestRunsLocator
+    fun withoutDetailsField(): TestRunsLocator
 
     /**
      * If expandMultipleInvocations is enabled, individual runs of tests, which were executed several

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/rest.kt
@@ -43,6 +43,10 @@ internal interface TeamCityService {
     fun testOccurrences(@Query("locator") locator: String, @Query("fields") fields: String?): TestOccurrencesBean
 
     @Headers("Accept: application/json")
+    @GET("/app/rest/testOccurrences/{id}")
+    fun testOccurrence(@Path("id") id: String, @Query("fields") fields: String?): TestOccurrenceBean
+
+    @Headers("Accept: application/json")
     @GET("/app/rest/vcs-roots")
     fun vcsRoots(@Query("locator") locator: String? = null): VcsRootListBean
 
@@ -556,9 +560,8 @@ internal open class TestBean {
     var id: String? = null
 }
 
-internal open class TestOccurrenceBean {
+internal open class TestOccurrenceBean: IdBean() {
     var name: String? = null
-    var id: String? = null
     var status: String? = null
     var ignored: Boolean? = null
     var duration: Long? = null
@@ -575,7 +578,17 @@ internal open class TestOccurrenceBean {
     var firstFailed: BuildBean? = null
 
     companion object {
-        val filter = "testOccurrence(name,id,status,ignored,muted,currentlyMuted,newFailure,duration,ignoreDetails,details,firstFailed(id),nextFixed(id),build(id),test(id),metadata)"
+        private const val minimalFields = "name,id,status,ignored,muted,currentlyMuted,newFailure,duration,ignoreDetails,firstFailed(id),nextFixed(id),build(id),test(id),metadata"
+        val fullFieldsFilter = getFieldsFilter(true)
+
+        fun getFieldsFilter(withDetails: Boolean): String {
+            val params = mutableListOf(minimalFields)
+            if (withDetails) {
+                params.add("details")
+            }
+
+            return "testOccurrence(${params.joinToString(",")})"
+        }
     }
 }
 


### PR DESCRIPTION
We can observe OOM due to the large number of red tests in the build. This happens because tests are requested with the `details` field, which can contain large text.