### PR TITLE
Paging implementation: fix nextHref encoding

### DIFF
--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/coroutines/rest.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/coroutines/rest.kt
@@ -17,7 +17,7 @@ internal interface TeamCityService {
     @Streaming
     @Headers("Accept: application/json")
     @GET("{path}")
-    suspend fun root(@Path("path", encoded = true) path: String, @QueryMap(encoded = true) encodedParams: Map<String, String>): Response<ResponseBody>
+    suspend fun root(@Path("path", encoded = true) path: String, @QueryMap(encoded = false) encodedParams: Map<String, String>): Response<ResponseBody>
 
     @Headers("Accept: application/json")
     @GET("app/rest/builds")


### PR DESCRIPTION
When data is paged, `nextHref` returned by TeamCity server is not encoded.

Previously, teamcity-rest-client was mistakenly configured to send value without encoding. This PR fixes the behavior and introduces a test