### PR TITLE
Add ability to bind requests to a specific node in a multi-node TeamCity setup

### DIFF
--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/builder.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/builder.kt
@@ -115,7 +115,8 @@ class TeamCityInstanceBuilder(serverUrl: String) {
     }
 
     /**
-     *
+     * Specifies how to route requests to different TeamCity nodes in a multinode TeamCity setup.
+     * Does not affect a single node setup.
      */
     fun selectNode(selector: NodeSelector): TeamCityInstanceBuilder {
         this.nodeSelector = selector

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/builder.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/builder.kt
@@ -25,6 +25,7 @@ class TeamCityInstanceBuilder(serverUrl: String) {
     private var retryMaxAttempts: Int = 3
     private var retryInitialDelayMs: Long = 1000
     private var retryMaxDelayMs: Long = 1000
+    private var nodeId: String? = null
 
     /**
      * Creates guest authenticated accessor. Default setting.
@@ -114,12 +115,24 @@ class TeamCityInstanceBuilder(serverUrl: String) {
     }
 
     /**
+     * Binds requests to the given server [nodeId] using `X-TeamCity-Node-Id-Cookie` cookie.
+     *
+     * Binding relies on a proxy in front of TeamCity server which should be set up in accordance to
+     * [TeamCity Multinode Setup for High Availability](https://www.jetbrains.com/help/teamcity/multinode-setup.html) documentation.
+     */
+    fun bindToNode(nodeId: String): TeamCityInstanceBuilder {
+        this.nodeId = nodeId
+        return this
+    }
+
+    /**
      * Build instance over coroutines
      */
     fun build(): TeamCityCoroutinesInstance = TeamCityCoroutinesInstanceImpl(
         serverUrl,
         urlBase.value,
-        authHeader, 
+        authHeader,
+        nodeId,
         logResponses,
         timeout,
         timeoutTimeUnit,

--- a/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/coroutines/nodePinning.kt
+++ b/teamcity-rest-client-impl/src/main/kotlin/org/jetbrains/teamcity/rest/coroutines/nodePinning.kt
@@ -1,0 +1,55 @@
+package org.jetbrains.teamcity.rest.coroutines
+
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+import org.jetbrains.teamcity.rest.NodeSelector
+
+fun NodeSelector.toCookieJar(): CookieJar {
+    return when(this) {
+        is NodeSelector.PinToNode -> PinToNodeCookieJar(this.nodeId)
+        is NodeSelector.ServerControlled -> ServerControlledRouting()
+        is NodeSelector.Unspecified -> CookieJar.NO_COOKIES
+    }
+}
+
+private class ServerControlledRouting: CookieJar {
+    private var serverProvidedNodeId: String? = null
+    override fun loadForRequest(url: HttpUrl): List<Cookie> {
+        val targetNodeId = serverProvidedNodeId ?: return emptyList()
+
+        val domain = url.topPrivateDomain() ?: return emptyList()
+
+        return listOf(
+            Cookie.Builder()
+                .domain(domain)
+                .name("X-TeamCity-Node-Id-Cookie")
+                .value(targetNodeId)
+                .build()
+        )
+    }
+
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+        cookies
+            .find { it.name == "X-TeamCity-Node-Id-Cookie" }
+            ?.let { serverProvidedNodeId = it.value }
+    }
+}
+
+private class PinToNodeCookieJar(val nodeId: String): CookieJar {
+    override fun loadForRequest(url: HttpUrl): List<Cookie> {
+        val domain = url.topPrivateDomain() ?: return emptyList()
+
+        return listOf(
+            Cookie.Builder()
+                .domain(domain)
+                .name("X-TeamCity-Node-Id-Cookie")
+                .value(nodeId)
+                .build()
+        )
+    }
+
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+        // noop, same as CookieJar.NO_COOKIES
+    }
+}


### PR DESCRIPTION
Usage example:
```
import org.jetbrains.teamcity.rest.BuildId
import org.jetbrains.teamcity.rest.TeamCityInstanceBuilder;

val tc = TeamCityInstanceBuilder("https://<multi-node-server>")
    .bindToNode("secondary-node")
    .withTokenAuth("<token>")
    .build()
```